### PR TITLE
ラーメン画像の投稿機能実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@
 !/tmp/.keep
 
 # Ignore uploaded files in development
+/public/uploads/
+
 /storage/*
 !/storage/.keep
 

--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,7 @@ gem 'devise'
 gem 'rails-i18n'
 gem 'haml-rails'
 gem 'font-awesome-rails'
+gem 'carrierwave'
+gem 'mini_magick'
+gem 'fog-aws'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    carrierwave (2.0.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     childprocess (3.0.0)
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
@@ -83,10 +90,28 @@ GEM
       warden (~> 1.2.3)
     erubi (1.9.0)
     erubis (2.7.0)
+    excon (0.68.0)
     execjs (2.7.0)
     ffi (1.11.3)
+    fog-aws (3.5.2)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -105,7 +130,11 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.9.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.13, < 3)
     io-like (0.3.0)
+    ipaddress (0.8.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     listen (3.1.5)
@@ -120,11 +149,16 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.3)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     mimemagic (0.3.3)
+    mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
     msgpack (1.3.1)
+    multi_json (1.14.1)
     mysql2 (0.5.2)
     nio4r (2.5.2)
     nokogiri (1.10.7)
@@ -175,6 +209,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.16)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.14.1)
       sexp_processor (~> 4.9)
@@ -236,13 +272,16 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
+  carrierwave
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  fog-aws
   font-awesome-rails
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-rails
   puma (~> 3.11)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Things you may want to cover:
 ## 2. visit_counts Table
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|shop_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|shop_id|references|null: false, foreign_key: true|
 |visit_date|datetime|null: false|
 |count|integer|null: false|
 
@@ -39,7 +39,7 @@ Things you may want to cover:
 ## 3. shops Table
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 |name|string|null: false|
 |address|string|null: false|
 |map|string|null: false|
@@ -57,7 +57,7 @@ Things you may want to cover:
 ## 4. noodle_images Table
 |Column|Type|Options|
 |------|----|-------|
-|shop_id|integer|null: false, foreign_key: true|
+|shop_id|references|null: false, foreign_key: true|
 |image|string|null: false|
 
 ### Association

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,7 +1,6 @@
 class ShopsController < ApplicationController
   before_action :set_shop, only: [:edit, :update, :destroy]
   before_action :set_sidebar, only: [:show, :new, :create, :edit, :update]
-  # before_action :set_noodle_image, only: [:edit, :update]
 
   def show
     @shop = Shop.find(params[:id])
@@ -9,16 +8,15 @@ class ShopsController < ApplicationController
 
   def new
     @shop = current_user.shops.new
-    # @noodle_images = current_user.NoodleImage.new
+    @shop.noodle_images.build
   end
 
   def create
     @shop = current_user.shops.new(shop_params)
-    if @shop.save
-      redirect_to root_path
-    else
-      render :new
-    end
+    @shop.save!
+    redirect_to root_path
+  rescue
+    render :new
   end
 
   def edit
@@ -39,20 +37,12 @@ class ShopsController < ApplicationController
 
   private
   def shop_params
-    params.require(:shop).permit(:name, :address, :map, :horiday, :opening_hours, :menu, :rule, :detail)
+    params.require(:shop).permit(:name, :address, :map, :horiday, :opening_hours, :menu, :rule, :detail, noodle_images_attributes: [:id,:image])
   end
-
-  # def noodle_image_params
-  #   params.require(:noodle_images).require(:image)
-  # end
 
   def set_shop
     @shop = current_user.shops.find(params[:id])
   end
-
-  # def set_noodle_image
-  #   @noodle_image = NoodleImage.find(params[:id])
-  # end
 
   def set_sidebar
     @shops = Shop.where(params[:id])

--- a/app/models/noodle_image.rb
+++ b/app/models/noodle_image.rb
@@ -1,0 +1,9 @@
+class NoodleImage < ApplicationRecord
+  belongs_to :shop, inverse_of: :noodle_images
+
+  mount_uploader :image, ImageUploader
+
+  validates :image,  presence: true
+
+
+end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,6 +1,7 @@
 class Shop < ApplicationRecord
   belongs_to :user
-  # has_many :noodle_images, dependent: :destroy
+  has_many :noodle_images, dependent: :destroy, inverse_of: :shop
+  accepts_nested_attributes_for :noodle_images
 
   validates :name,  presence: true
   validates :address,  presence: true

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,52 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+  process resize_to_fit: [600, 600]
+
+  # Choose what kind of storage to use for this uploader:
+  # 環境ごとに保存先変更
+  if Rails.env.development? || Rails.env.test? 
+    storage :file
+  else
+    storage :fog
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/shops/_form.html.haml
+++ b/app/views/shops/_form.html.haml
@@ -23,6 +23,10 @@
         .label__top ローカルルール
         = f.text_field :rule, class: 'form-panel'
       .label.clearfix
+        .label__top ローカルルール
+        = f.fields_for :noodle_images do |c|
+          = c.file_field :image
+      .label.clearfix
         .label__top メニュー詳細
         = f.text_field :detail, class: 'form-panel'
       .label.clearfix

--- a/app/views/shops/show.html.haml
+++ b/app/views/shops/show.html.haml
@@ -26,7 +26,6 @@
         .shop-content
           = @shop.rule
         .shop-noodleimage
-          -# ラーメンの写真（noodle_images）
-          =image_tag("/top_image/top.jpg", width: "45%" , alt: "top", class: "top-image")
+          = image_tag @shop.noodle_images.first.image.to_s
         .shop-content
           = @shop.detail

--- a/db/migrate/20191231092639_create_shops.rb
+++ b/db/migrate/20191231092639_create_shops.rb
@@ -1,9 +1,9 @@
 class CreateShops < ActiveRecord::Migration[5.2]
   def change
     create_table :shops do |t|
-      t.integer :user_id,        null: false, foreign_key: true
+      t.references :user,        null: false, foreign_key: true
       t.string  :name,           null: false
-      t.string  :address,   null: false
+      t.string  :address,        null: false
       t.string  :map,            null: false
       t.string  :horiday,        null: false
       t.text    :opening_hours,  null: false

--- a/db/migrate/20200109080520_create_noodle_images.rb
+++ b/db/migrate/20200109080520_create_noodle_images.rb
@@ -1,0 +1,9 @@
+class CreateNoodleImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :noodle_images do |t|
+      t.string :image,           null: false
+      t.references :shop,        null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_31_092639) do
+ActiveRecord::Schema.define(version: 2020_01_09_080520) do
+
+  create_table "noodle_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "image", null: false
+    t.bigint "shop_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shop_id"], name: "index_noodle_images_on_shop_id"
+  end
 
   create_table "shops", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.string "name", null: false
     t.string "address", null: false
     t.string "map", null: false
@@ -24,6 +32,7 @@ ActiveRecord::Schema.define(version: 2019_12_31_092639) do
     t.text "detail"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_shops_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -39,4 +48,6 @@ ActiveRecord::Schema.define(version: 2019_12_31_092639) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "noodle_images", "shops"
+  add_foreign_key "shops", "users"
 end

--- a/test/fixtures/noodle_images.yml
+++ b/test/fixtures/noodle_images.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  image: MyString
+
+two:
+  image: MyString

--- a/test/models/noodle_image_test.rb
+++ b/test/models/noodle_image_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class NoodleImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
・店舗のラーメン画像のバックエンド実装。
・店舗のラーメン画像のフロントエンド実装。
・gitignoreに開発環境の画像はgit管理から除外するように記載。
・画像の保存場所は開発環境と本番環境で条件分岐。
# Why
・画像が投稿できることによりユーザーが店舗毎のイメージができるようになる。