### PR TITLE
ラーメン画像のバリデーション

### DIFF
--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -16,5 +16,7 @@ class Shop < ApplicationRecord
   validates :opening_hours,  presence: true
   validates :menu,  presence: true
 
+  validates :noodle_images,  presence: true
+
 
 end


### PR DESCRIPTION
# What
- ラーメン画像のバリデーション。空では保存できない。
# Why
- ラーメン画像登録時にバリデーションがうまくかかっておらず、エラーとなっていたため。