### PR TITLE
shops_controllerのエラー修正

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -16,7 +16,7 @@ class ShopsController < ApplicationController
 
   def create
     @shop = current_user.shops.new(shop_params)
-    @shop.save
+    @shop.save!
     redirect_to root_path
   rescue
     render :new


### PR DESCRIPTION
# What
- 新規店舗登録時にバリデーションで保存できない際にホーム画面に飛んでしまう。
- 以前はしっかり機能していた。
# Why
- 既存のページのままにすることによって再度入力の手間が省ける。